### PR TITLE
Simplify users/groups table, add content table

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -1,3 +1,4 @@
+# Make connection to Connect client
 get_client <- function(
     server_name = Sys.getenv("CONNECT_SERVER"),
     api_key = Sys.getenv("CONNECT_API_KEY")
@@ -5,41 +6,125 @@ get_client <- function(
   connectapi::connect(server_name, api_key)
 }
 
+# Return a dataframe with guid and group name
 get_groups <- function(client = get_client()) {
   client |>
     connectapi::get_groups() |>
     dplyr::select(guid, name)
 }
 
-get_group_membership <- function(client = get_client(), groups = get_groups()) {
-  groups[["guid"]] |>
+# Return a list of dataframes of user information, one named element per group
+get_group_membership <- function(client = get_client()) {
+
+  groups <- get_groups(client)
+
+  groups_members <- groups[["guid"]] |>
     purrr::set_names(groups[["name"]]) |>
     purrr::map(\(guid) connectapi::get_group_members(client, guid))
+
+  # Retain empty groups by giving them '[None]' as a user
+  for (group in names(groups_members)) {
+    df_is_empty <- nrow(groups_members[[group]]) == 0
+    if (df_is_empty) {  # i.e. no users were returned
+      groups_members[[group]] <- tibble::tibble(username = "[none]")
+    }
+  }
+
+  groups_members
+
 }
 
-get_user_groups <- function(group_membership = get_group_membership()) {
+# Return a dataframe with one row per username and group membership
+get_user_groups <- function(client = get_client()) {
+
+  group_membership <- get_group_membership(client)
+
   group_membership |>
     purrr::list_rbind(names_to = "group") |>
     dplyr::select(username, group)
+
 }
 
-get_all_users <- function(client = get_client()) {
-  connectapi::get_users(client) |>
+# Return a dataframe of user details (username, name, user_role, active_time)
+get_all_users <- function(
+    client = get_client(),
+    include_guid = FALSE
+) {
+
+  users <- connectapi::get_users(client) |>
     dplyr::mutate(
       name = glue::glue("{first_name} {last_name}") |>
         stringr::str_squish()
     ) |>
-    dplyr::select(username, name, user_role, active_time)
+    dplyr::select(guid, username, name, user_role, active_time)
+
+  if (!include_guid) dplyr::select(users, -guid) else return(users)
+
 }
 
-get_all_users_groups <- function(
-    all_users = get_all_users(),
-    user_groups = get_user_groups()
-) {
+# Returns a dataframe of user details with one row per user and group
+get_all_users_groups <- function(client = get_client()) {
+
+  all_users <- get_all_users(client)
+  user_groups <- get_user_groups(client)
+
   all_users |>
     dplyr::full_join(
       user_groups,
       by = "username",
       relationship = "many-to-many"
+    ) |>
+    dplyr::mutate(
+      last_login = as.character(format(active_time, "%Y-%m-%d")),
+      .after = user_role
+    ) |>
+    dplyr::select(-active_time) |>
+    dplyr::mutate(
+      dplyr::across(
+        tidyselect::everything(),
+        \(column) tidyr::replace_na(column, "[none]")
+      )
+    ) |>
+    dplyr::arrange(tolower(username), tolower(group))
+
+}
+
+# Returns a dataframe of content details, one row per content item
+get_content <- function(client = get_client()) {
+  client |>
+    connectapi::get_content() |>
+    tidyr::hoist(owner, "username") |>
+    dplyr::mutate(
+      has_tags = purrr::map(tags, \(x) !is.null(x)),
+      has_tags = unlist(has_tags),
+      app_mode = dplyr::if_else(
+        content_category != "",
+        glue::glue("{app_mode} ({content_category})"),
+        app_mode
+      )
+    ) |>
+    dplyr::select(
+      content_id = id,
+      name,
+      title,
+      description,
+      mode = app_mode,
+      has_tags,
+      last_deployed_time,
+      owner_username = username,
+      content_url,
+      dashboard_url
+    ) |>
+    dplyr::arrange(dplyr::desc(as.numeric(content_id))) |>
+    dplyr::mutate(
+      last_deployed_time = format(last_deployed_time, "%Y-%m-%d %H:%M"),
+      dplyr::across(
+        dplyr::where(is.character),
+        \(col) dplyr::na_if(col, "")
+      ),
+      dplyr::across(
+        tidyselect::everything(),
+        \(column) tidyr::replace_na(column, "[none]")
+      )
     )
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -7,14 +7,6 @@ check_env_vars <- function(required_env_vars) {
   }
 }
 
-# Simple count of non-NA users or groups
-get_n <- function(client = get_client(), var) {
-  get_user_groups(client) |>
-    dplyr::filter(!is.na({{ var }})) |>
-    dplyr::distinct({{ var }}) |>
-    nrow()
-}
-
 # Create a {DT} datatable with common settings
 create_dt <- function(dat, type = c("users", "content")) {
   dat |>

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,37 @@
+# Exit rendering if environment variables are missing (prevents error emails)
+check_env_vars <- function(required_env_vars) {
+  if (any(Sys.getenv(required_env_vars) == "")) {
+    cat("One of the following environment variables was not set, so exiting \n\n")
+    cat(paste("*", required_env_vars, collapse = "\n"), "\n\n")
+    knitr::knit_exit()
+  }
+}
+
+# Simple count of non-NA users or groups
+get_n <- function(client = get_client(), var) {
+  get_user_groups(client) |>
+    dplyr::filter(!is.na({{ var }})) |>
+    dplyr::distinct({{ var }}) |>
+    nrow()
+}
+
+# Create a {DT} datatable with common settings
+create_dt <- function(dat, type = c("users", "content")) {
+  dat |>
+    DT::datatable(
+      filter = "top",
+      rownames = FALSE,
+      escape = FALSE,  # for URLs
+      extensions = "Buttons",
+      options = list(
+        dom = "Bftipr",
+        autoWidth = TRUE,
+        buttons = list(
+          list(
+            extend = "csv",
+            title = glue::glue("{Sys.Date()}_su-posit-connect_{type}-lookup")
+          )
+        )
+      )
+    )
+}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 [<img src='https://img.shields.io/badge/Posit_Connect-deployed-447099?style=flat&labelColor=white&logo=Posit&logoColor=447099'>](https://connect.strategyunitwm.nhs.uk/posit-connect-people/)
 
-A simple interface for a quick understanding of users and groups in Posit Connect. Overcomes missing functionality in the platform itself.
+A simple interface for a quick understanding of users and content on Posit Connect.
+Overcomes some missing functionality in the platform itself.
 
-To run locally, you'll need to add an `.Renviron` file to the project root, which contains the keys specified in the provided `.Renviron.example` file. Contact the repo owner for the required values.
+The report itself is [deployed to Connect](https://connect.strategyunitwm.nhs.uk/posit-connect-people/) on schedule.
+
+To run locally, you'll need to add an `.Renviron` file to the project root, which contains the keys specified in the provided `.Renviron.example` file.
+Contact the Data Science team for the required values.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 [<img src='https://img.shields.io/badge/Posit_Connect-deployed-447099?style=flat&labelColor=white&logo=Posit&logoColor=447099'>](https://connect.strategyunitwm.nhs.uk/posit-connect-people/)
 
-A simple interface for a quick understanding of users and content on Posit Connect.
+A simple interface for a quick understanding of users and content on our Posit Connect server.
 Overcomes some missing functionality in the platform itself.
 
-The report itself is [deployed to Connect](https://connect.strategyunitwm.nhs.uk/posit-connect-people/) on schedule.
+The report itself is [deployed to Connect](https://connect.strategyunitwm.nhs.uk/posit-connect-people/) on schedule (login and permissions required).
 
 To run locally, you'll need to add an `.Renviron` file to the project root, which contains the keys specified in the provided `.Renviron.example` file.
 Contact the Data Science team for the required values.

--- a/index.qmd
+++ b/index.qmd
@@ -1,110 +1,79 @@
 ---
-title: 'Lookup: Posit Connect People'
+title: "Lookup: Posit Connect People and Content"
 date: "last-modified"
 date-format: D MMM YYYY HH:mm
-format: html
+author: Data Science Team, The Strategy Unit
+format:
+  html:
+    page-layout: full
 execute:
   echo: false
 resource_files:
  - R/api.R
+ - R/utils.R
 ---
 
 ```{r}
 #| label: check-env-vars
 #| results: "asis"
-required_env_vars <- c("CONNECT_SERVER", "CONNECT_API_KEY")
-if (any(Sys.getenv(required_env_vars) == "")) {
-  cat("One of the following environment variables was not set, so exiting \n\n")
-  cat(paste("*", required_env_vars, collapse = "\n"), "\n\n")
-  knitr::knit_exit() 
-}
+
+list.files("R", "\\.R$", , TRUE) |> purrr::walk(source)
+check_env_vars(c("CONNECT_SERVER", "CONNECT_API_KEY"))
 ```
 
 ```{r}
-#| label: prepare-workspace
+#| label: prepare-variables
 #| include: false
-list.files("R", "\\.R$", , TRUE) |> purrr::walk(source)
+
 server_name <- Sys.getenv("CONNECT_SERVER")
 people_path <- glue::glue("{server_name}connect/#/people/")
-dat <- get_all_users_groups() |> 
-  tidyr::replace_na(list(username = "[No user]", group = "[No group]"))
+content_path <- glue::glue("{server_name}connect/#/content/")
+
+client <- get_client()
+users_groups <- get_all_users_groups(client)
+content <- get_content(client)
+
+n_users <- users_groups |>
+  dplyr::filter(username != "[none]") |> 
+  dplyr::distinct() |>
+  nrow()
+
+n_groups <- users_groups |>
+  dplyr::filter(group != "[none]") |> 
+  dplyr::distinct() |>
+  nrow()
+
+n_content <- nrow(content)
 ```
 
 ## Purpose
 
-A quick lookup of [users and groups](`r people_path`) on the server `r server_name`. Find [the source on GitHub](https://github.com/The-Strategy-Unit/posit-connect-people/).
+This page contains tabular lookups of [users](`r people_path`) and [content](`r content_path`) on the server [`r server_name`](`r server_name`). Find [the source on GitHub](https://github.com/The-Strategy-Unit/posit-connect-people/).
 
-## By user
+## Users and groups
+
+This table shows one row per user and group. There are `r n_users` users and `r n_groups` groups. Note that it's possible for users not to have a group and vice versa. You can search, sort and filter the data and click the 'CSV' button to download the current view.
 
 ```{r}
-#| label: by-user
-dat |>
-  dplyr::select(username, group) |> 
-  dplyr::arrange(tolower(username), tolower(group)) |> 
-  reactable::reactable(
-    groupBy = "username",
-    columns = list(
-      username = reactable::colDef(
-        filterable = TRUE,
-        filterInput = function(values, name) {
-          htmltools::tags$select(
-            # Set to undefined to clear the filter
-            onchange = sprintf("Reactable.setFilter('cars-select', '%s', event.target.value || undefined)", name),
-            # "All" has an empty value to clear the filter, and is the default option
-            htmltools::tags$option(value = "", "All"),
-            lapply(unique(values), htmltools::tags$option),
-            "aria-label" = sprintf("Filter %s", name),
-            style = "width: 100%; height: 28px;"
-          )
-        }
-      )
-    )
-  )
+#| label: users-table
+
+users_groups |> 
+  dplyr::mutate(dplyr::across(dplyr::where(is.character), as.factor)) |>
+  create_dt("users")
 ```
 
-## By group
+## Content
+
+This table shows one row per content item. There are `r n_content` content items. You can search, sort and filter the data and click the 'CSV' button to download the current view. Click the links in the `*_url` columns to open the item with or without the Posit Connect dashboard framing the content.
 
 ```{r}
-#| label: by-group
-dat |>
-  dplyr::select(group, username) |>
-  dplyr::arrange(tolower(group), tolower(username)) |> 
-  reactable::reactable(
-    groupBy = "group",
-    columns = list(
-      group = reactable::colDef(
-        filterable = TRUE,
-        filterInput = function(values, name) {
-          htmltools::tags$select(
-            # Set to undefined to clear the filter
-            onchange = sprintf("Reactable.setFilter('cars-select', '%s', event.target.value || undefined)", name),
-            # "All" has an empty value to clear the filter, and is the default option
-            htmltools::tags$option(value = "", "All"),
-            lapply(unique(values), htmltools::tags$option),
-            "aria-label" = sprintf("Filter %s", name),
-            style = "width: 100%; height: 28px;"
-          )
-        }
-      )
-    )
-  )
-```
+#| label: content-table
 
-## All data
-
-```{r}
-#| label: all-data
-htmltools::browsable(
-  htmltools::tagList(
-    htmltools::tags$button(
-      "Download CSV",
-      onclick = "Reactable.downloadDataCSV('data-table', 'posit-connect-people.csv')"
-    ),
-    reactable::reactable(
-      dat |> dplyr::arrange(tolower(username), tolower(group)),
-      filterable = TRUE,
-      elementId = "data-table",
-    )
-  )
-)
+content |> 
+  dplyr::mutate(
+    content_url = glue::glue("<a href='{content_url}'>Link</a>"),
+    dashboard_url = glue::glue("<a href='{dashboard_url}'>Link</a>"),
+    dplyr::across(dplyr::where(is.character), as.factor)
+  ) |> 
+  create_dt("content")
 ```

--- a/renv.lock
+++ b/renv.lock
@@ -9,6 +9,23 @@
     ]
   },
   "Packages": {
+    "DT": {
+      "Package": "DT",
+      "Version": "0.33",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "crosstalk",
+        "htmltools",
+        "htmlwidgets",
+        "httpuv",
+        "jquerylib",
+        "jsonlite",
+        "magrittr",
+        "promises"
+      ],
+      "Hash": "64ff3427f559ce3f2597a4fe13255cb6"
+    },
     "PKI": {
       "Package": "PKI",
       "Version": "0.1-12",
@@ -29,6 +46,17 @@
         "R"
       ],
       "Hash": "470851b6d5d0ac559e9d01bb352b4021"
+    },
+    "Rcpp": {
+      "Package": "Rcpp",
+      "Version": "1.0.13",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "methods",
+        "utils"
+      ],
+      "Hash": "f27411eb6d9c3dada5edd444b8416675"
     },
     "askpass": {
       "Package": "askpass",
@@ -98,14 +126,14 @@
     },
     "cachem": {
       "Package": "cachem",
-      "Version": "1.0.8",
+      "Version": "1.1.0",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "fastmap",
         "rlang"
       ],
-      "Hash": "c35768291560ce302c0a6589f92e837d"
+      "Hash": "cd9a672193789068eb5a2aad65a0dedf"
     },
     "cli": {
       "Package": "cli",
@@ -142,13 +170,26 @@
     },
     "cpp11": {
       "Package": "cpp11",
-      "Version": "0.4.7",
+      "Version": "0.5.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "5a295d7d963cc5035284dcdbaf334f4e"
+      "Hash": "9df43854f1c84685d095ed6270b52387"
+    },
+    "crosstalk": {
+      "Package": "crosstalk",
+      "Version": "1.2.1",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R6",
+        "htmltools",
+        "jsonlite",
+        "lazyeval"
+      ],
+      "Hash": "ab12c7b080a57475248a30f4db6298c0"
     },
     "curl": {
       "Package": "curl",
@@ -311,6 +352,21 @@
       ],
       "Hash": "04291cc45198225444a397606810ac37"
     },
+    "httpuv": {
+      "Package": "httpuv",
+      "Version": "1.6.15",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "R6",
+        "Rcpp",
+        "later",
+        "promises",
+        "utils"
+      ],
+      "Hash": "d55aa087c47a63ead0f6fc10f8fa1ee0"
+    },
     "httr": {
       "Package": "httr",
       "Version": "1.4.7",
@@ -361,6 +417,27 @@
         "yaml"
       ],
       "Hash": "acf380f300c721da9fde7df115a5f86f"
+    },
+    "later": {
+      "Package": "later",
+      "Version": "1.3.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "Rcpp",
+        "rlang"
+      ],
+      "Hash": "a3e051d405326b8b0012377434c62b37"
+    },
+    "lazyeval": {
+      "Package": "lazyeval",
+      "Version": "0.2.2",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R"
+      ],
+      "Hash": "d908914ae53b04d4c0c0fd72ecc35370"
     },
     "lifecycle": {
       "Package": "lifecycle",
@@ -455,6 +532,22 @@
       ],
       "Hash": "01f28d4278f15c76cddbea05899c5d6f"
     },
+    "promises": {
+      "Package": "promises",
+      "Version": "1.3.0",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R6",
+        "Rcpp",
+        "fastmap",
+        "later",
+        "magrittr",
+        "rlang",
+        "stats"
+      ],
+      "Hash": "434cd5388a3979e74be5c219bcd6e77d"
+    },
     "purrr": {
       "Package": "purrr",
       "Version": "1.0.2",
@@ -479,31 +572,6 @@
         "R"
       ],
       "Hash": "5e3c5dc0b071b21fa128676560dbe94d"
-    },
-    "reactR": {
-      "Package": "reactR",
-      "Version": "0.5.0",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "htmltools"
-      ],
-      "Hash": "c9014fd1a435b2d790dd506589cb24e5"
-    },
-    "reactable": {
-      "Package": "reactable",
-      "Version": "0.4.4",
-      "Source": "Repository",
-      "Repository": "CRAN",
-      "Requirements": [
-        "R",
-        "digest",
-        "htmltools",
-        "htmlwidgets",
-        "jsonlite",
-        "reactR"
-      ],
-      "Hash": "6069eb2a6597963eae0605c1875ff14c"
     },
     "renv": {
       "Package": "renv",


### PR DESCRIPTION
Close #15. Sufficient to close https://github.com/The-Strategy-Unit/data_science_planning/issues/33?

* Simplify to a single interactive {DT} table of users and groups.
* Add a {DT} table for selected information about Connect content items.
* Add CSV download buttons.
* Add table preamble with explanation and counts.
* Widen to full page layout to better accommodate tables.

Probably easiest to check by rendering locally, or I can share screen. Might be useful to deploy this ahead of this Friday's migration chat. 