### PR TITLE
Add 'locked' column, deploy script

### DIFF
--- a/R/api.R
+++ b/R/api.R
@@ -63,7 +63,8 @@ get_all_users <- function(
       name,
       email,
       user_role,
-      active_time
+      active_time,
+      locked
     )
 
   if (!include_guid) dplyr::select(users, -guid) else return(users)
@@ -88,6 +89,7 @@ get_all_users_groups <- function(client = get_client()) {
     ) |>
     dplyr::select(-active_time) |>
     dplyr::mutate(
+      dplyr::across(tidyselect::everything(), as.character),
       dplyr::across(
         tidyselect::everything(),
         \(column) tidyr::replace_na(column, "[none]")

--- a/deploy.R
+++ b/deploy.R
@@ -1,0 +1,14 @@
+deploy <- function(server_name, app_id) {
+  rsconnect::deployDoc(
+    server = server_name,
+    appId = app_id,
+    doc = "index.qmd",
+    appName = "posit-connect-people",
+    appTitle = "Lookup: Posit Connect People",
+    lint = FALSE,
+    forceUpdate = TRUE
+  )
+}
+
+deploy("connect.strategyunitwm.nhs.uk", 321)
+deploy("connect.su.mlcsu.org", 82)

--- a/index.qmd
+++ b/index.qmd
@@ -34,12 +34,22 @@ users_groups <- get_all_users_groups(client)
 content <- get_content(client)
 
 n_users <- users_groups |>
-  dplyr::filter(username != "[none]") |> 
+  dplyr::filter(username != "[none]" & locked == "FALSE") |> 
+  dplyr::distinct(username) |>
+  nrow()
+
+n_users_locked <- users_groups |>
+  dplyr::filter(username != "[none]" & locked == "TRUE") |> 
   dplyr::distinct(username) |>
   nrow()
 
 n_groups <- users_groups |>
-  dplyr::filter(group != "[none]") |> 
+  dplyr::filter(group != "[none]" & username != "[none]") |> 
+  dplyr::distinct(group) |>
+  nrow()
+
+n_groups_empty <- users_groups |>
+  dplyr::filter(group != "[none]" & username == "[none]") |>
   dplyr::distinct(group) |>
   nrow()
 
@@ -52,7 +62,7 @@ This page contains tabular lookups of [users](`r people_path`) and [content](`r 
 
 ## Users and groups
 
-This table shows one row per user and group. There are `r n_users` users and `r n_groups` groups. Note that it's possible for users not to have a group and vice versa. You can search, sort and filter the data and click the 'CSV' button to download the current view.
+This table shows one row per user and group. Note that it's possible for users not to have a group and vice versa. There are `r n_users` users (plus `r n_users_locked` locked users) and `r n_groups` groups (plus `r n_groups_empty` empty groups). You can search, sort and filter the data and click the 'CSV' button to download the current view.
 
 ```{r}
 #| label: users-table

--- a/renv.lock
+++ b/renv.lock
@@ -619,7 +619,7 @@
     },
     "rsconnect": {
       "Package": "rsconnect",
-      "Version": "1.2.2",
+      "Version": "1.3.4",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -638,7 +638,7 @@
         "tools",
         "yaml"
       ],
-      "Hash": "77e9ed1307e84cd7ca1c7fb2cd7bbfe2"
+      "Hash": "315454d2f50d117ef58691d0bf50fe63"
     },
     "rstudioapi": {
       "Package": "rstudioapi",

--- a/renv.lock
+++ b/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.4.0",
+    "Version": "4.4.3",
     "Repositories": [
       {
         "Name": "CRAN",
@@ -354,7 +354,7 @@
     },
     "httpuv": {
       "Package": "httpuv",
-      "Version": "1.6.15",
+      "Version": "1.6.16",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -365,7 +365,7 @@
         "promises",
         "utils"
       ],
-      "Hash": "d55aa087c47a63ead0f6fc10f8fa1ee0"
+      "Hash": "6c3c8728e40326de6529a5c46e377e5c"
     },
     "httr": {
       "Package": "httr",
@@ -475,13 +475,13 @@
     },
     "mime": {
       "Package": "mime",
-      "Version": "0.12",
+      "Version": "0.13",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "tools"
       ],
-      "Hash": "18e9c28c1d3ca1560ce30658b22ce104"
+      "Hash": "0ec19f34c72fab674d8f2b4b1c6410e1"
     },
     "openssl": {
       "Package": "openssl",
@@ -649,7 +649,7 @@
     },
     "sass": {
       "Package": "sass",
-      "Version": "0.4.9",
+      "Version": "0.4.10",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -659,11 +659,11 @@
         "rappdirs",
         "rlang"
       ],
-      "Hash": "d53dbfddf695303ea4ad66f86e99b95d"
+      "Hash": "3fb78d066fb92299b1d13f6a7c9a90a8"
     },
     "stringi": {
       "Package": "stringi",
-      "Version": "1.8.4",
+      "Version": "1.8.7",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -672,7 +672,7 @@
         "tools",
         "utils"
       ],
-      "Hash": "39e1144fd75428983dc3f63aa53dfa91"
+      "Hash": "2b56088e23bdd58f89aebf43a0913457"
     },
     "stringr": {
       "Package": "stringr",


### PR DESCRIPTION
Close #28.

* Pulled 'locked' status from API.
* Added boolean `locked` column to the table of users and groups.
* Adjusted in-text counts to ignore locked users and empty groups, but report them separately.
* Re-snapshotted with {renv}.
* Added `deploy.R` script (double-deploys to both servers for now).

Have updated the deployments already:

* https://connect.strategyunitwm.nhs.uk/posit-connect-people/
* https://connect.su.mlcsu.org/posit-connect-people/